### PR TITLE
Add install instruction for conda environment.

### DIFF
--- a/vector/install-conda.md
+++ b/vector/install-conda.md
@@ -18,7 +18,7 @@ Otherwise, on the command shell, you can launch Jupyter notebooks (after activat
 jupyter notebook
 ```
 
-### Removing and recreating the `geopandasenv` conda environment
+### Removing and recreating the `vectorenv` conda environment
 
 To delete the conda environment, first "deactivate" it if you've activated it in your shell session:
 ```bash

--- a/vector/install-conda.md
+++ b/vector/install-conda.md
@@ -1,0 +1,34 @@
+### Creating the `vectorenv` conda environment
+
+Open a terminal window and type the commands to create the environment and "activate" it.
+```bash
+conda env create environment.yml  # Will create an environment called "vectorenv"
+source activate vectorenv  # OSX and Linux
+activate vectorenv  # Windows
+```
+
+The `vectorenv` conda environment includes `geopandas` and its dependencies, which include (for vector-handling packages) `shapely`, `fiona`, `pyproj`, `descartes` and `pysal`, in addition to `pandas` and `numpy`. These will be handled automatically by the conda environment. Additional conda packages available in the environment include `pyepsg`, `geojson`, `folium` (for interactive maps in Jupyter notebooks), `rasterstats` (for simplified raster-vector analysis), `requests`, and `psycopg2` for access to vector data stored in PostGIS hosted in AWS (Amazon Web Services).
+
+### Starting Jupyter notebooks
+
+On Windows and MacOSX you may have a conda GUI application already installed, specially if you installed Anaconda. That application should let you select the `vectorenv` environment, then launch Jupyter notebook with that environment.
+
+Otherwise, on the command shell, you can launch Jupyter notebooks (after activating the environment) like this:
+```bash
+jupyter notebook
+```
+
+### Removing and recreating the `geopandasenv` conda environment
+
+To delete the conda environment, first "deactivate" it if you've activated it in your shell session:
+```bash
+source deactivate  # OSX and Linux
+deactivate  # Windows
+```
+
+Then remove the environment:
+```bash
+conda env remove -n vectorenv
+```
+
+You can create it again, from scratch, using the command described earlier.


### PR DESCRIPTION
## Overview

This PR adds setup instruction for the `vectorenv` environment, which addresses https://github.com/geohackweek/vector/issues/10. 