### PR TITLE
Add geoviews example as follow on to Missing Maps tutorial

### DIFF
--- a/vector/environment.yml
+++ b/vector/environment.yml
@@ -18,3 +18,6 @@ dependencies:
 - geoviews
 - osmnx
 - jupyter
+- holoviews
+- panel
+- cartopy


### PR DESCRIPTION
Includes 
    - pull in basemap tiles from various tile server urls for any lon lat
    - save tiles as geotif
    - re-project tiles as UTM
    - draw vertices and pull in as geopandas dataframe
